### PR TITLE
Виправив CMake конфігурацію

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,14 +19,18 @@ add_executable(simple_cpp_database src/main.cpp
         header/logic/Validator.h
         src/data/LibraryObject.cpp
 )
-include_directories(header)
-include_directories(header/logic/saver)
-include_directories(header/logic/loader)
-include_directories(header/data)
-include_directories(header/logic)
-include_directories(include/json/include/nlohmann)
-target_include_directories(simple_cpp_database PRIVATE header)
-target_include_directories(simple_cpp_database PRIVATE header/logic/saver)
-target_include_directories(simple_cpp_database PRIVATE header/logic/loader)
-target_include_directories(simple_cpp_database PRIVATE header/data)
-target_include_directories(simple_cpp_database PRIVATE header/logic)
+
+#include_directories(include/json/include/nlohmann)  тут помилка зверніть увагу в шляху
+
+# Вказуємо директорії заголовків безпосередньо для цільового файлу замість глобального оголошення
+# Переписав на використання target_include_directories замість include_directories
+# Такий підхід є більш модульним і забезпечує, що шляхи до заголовків застосовуються лише
+# для цілі 'simple_cpp_database', дотримуючись сучасних практик у Cmake.
+target_include_directories(simple_cpp_database PRIVATE
+        ${PROJECT_SOURCE_DIR}/header
+        ${PROJECT_SOURCE_DIR}/header/logic/saver
+        ${PROJECT_SOURCE_DIR}/header/logic/loader
+        ${PROJECT_SOURCE_DIR}/header/data
+        ${PROJECT_SOURCE_DIR}/header/logic
+        ${PROJECT_SOURCE_DIR}/include/json/single_include
+)


### PR DESCRIPTION
Замінив include_directories на target_include_directories для більш модульного налаштування. Використав модифікатор PRIVATE, щоб шляхи до заголовків застосовувалися лише до цілі `simple_cpp_database`.  Це забезпечує ізоляцію шляхів для конкретної цілі, дотримуючись сучасних практик CMake та спрощує конфігурацію для більших проєктів. P.S. не дуже гарна практика, завантажувати білд на репозиторій